### PR TITLE
build: Stay in homedir

### DIFF
--- a/build_ostree_components.sh
+++ b/build_ostree_components.sh
@@ -69,9 +69,8 @@ systemctl start libvirtd
 
 ## This part creates an install tree and install iso 
 
-cd ${BuildDir}
 echo '---------- installer ' >> ${LogFile}
-rpm-ostree-toolbox installer --overwrite --ostreerepo ${HomeDir}/repo -c  ${GitDir}/config.ini -o ${HomeDir}/installer |& tee ${LogFile}
+rpm-ostree-toolbox installer --overwrite --ostreerepo ${HomeDir}/repo -c  ${GitDir}/config.ini -o ${BuildDir}/installer |& tee ${LogFile}
 
 # we likely need to push the installer content to somewhere the following kickstart
 #  can pick the content from ( does it otherwise work with a file:/// url ? unlikely )


### PR DESCRIPTION
When we want to write to the builddir, reference it explicitly.  This
is the way toolbox is intended to be used - then it will pick up the
ostree repo from the homedir.